### PR TITLE
Add look-at-my.site to CORS whitelist

### DIFF
--- a/api/cors.go
+++ b/api/cors.go
@@ -20,6 +20,7 @@ var whitelistedHosts = map[string]bool{
 	"apis.infinitudecloud.com": true, // RELEASE
 	"latenight.apis.infinitudecloud.com": true, // BETA
 	"midnight.apis.infinitudecloud.com": true,  // DEVELOPMENT
+	"look-at-my.site": true,
 }
 
 func allowOrigin(clientOrigin string) bool {


### PR DESCRIPTION
Hi, 

I am creating a little app what checks HTTP(S) headers and suggest potential security loopholes for websites. It is at `look-at-my.site`. It is still work-in-progress at the moment, populated with mocks. I would like to add it to the whitelist so that I can use the API for part of my checks. 

Thanks!