### PR TITLE
Clarify that you don't have to listen on HTTP

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -104,7 +104,7 @@
     <p>In order to be accepted to the HSTS preload list through this form, your site must satisfy the following set of requirements:</p>
     <ol>
       <li>Serve a valid <b>certificate</b>.</li>
-      <li><b>Redirect</b> from HTTP to HTTPS on the same host.</li>
+      <li><b>Redirect</b> from HTTP to HTTPS on the same host, if you are listening on HTTP.</li>
       <li>Serve all <b>subdomains</b> over HTTPS.</li>
         <ul>
           <li>In particular, you must support HTTPS for the <tt>www</tt> subdomain if a DNS record for that subdomain exists.</li>


### PR DESCRIPTION
Per the following:

- chromium/hstspreload.appspot.com#47
- chromium/hstspreload@5c52e6516f3e2171bd6a75d641a2ddf099e36b35

It is no longer necessary to listen on HTTP *just* to serve a redirect to
HTTPS. Re-word the submission requirements to make this clear and match the
underlying library.